### PR TITLE
Fix to handle nested quotes in strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# `echo` (v0.0.1-alpha.0)
-A Go pacakge with script-like functionalities!
+# `Echo$` 
+Script-like functionalities wrapped in the rigid safety of Go!
 
 ## Start
 Create a session:

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,16 @@
+## TODO
+## v0.0.1-alpha.2
+- Fix nested quoted string parsing (i.e. '"value"' will fail)
+
+## Upcoming
+- Exit(statcode int, msg...string)
+- Store result of previous command in session (using special chars as keys, i.e. @?)
+- Ability to pipe result from previous cmd i.e.:
+  e.Pipe(e.Run(cmd), e.Run(cmd), e.Run(cmd))
+- Wrap command in a shell
+  e.Shell(e.Bash, "command")
+  e.Shellout(e.Bash, "command")
+- Item iterator:
+  e.ForEach(list interface{}, func(item))
+- Files iterator:
+  e.ForPath(paths interface{}, func(item)))

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -54,6 +54,23 @@ func TestEchoSplitWords(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "nested quotes",
+			str: func() string {
+				return `"a ab" aba 'bbb:"ccc"' "dd='ee'"`
+			},
+			test: func(parts []string) {
+				if len(parts) != 4 {
+					t.Error("unexpected number of split items:", len(parts), parts)
+				}
+				if parts[0] != "a ab" &&
+					parts[1] != "aba" &&
+					parts[2] != `bbb:"ccc"` &&
+					parts[3] != `dd='ee'` {
+					t.Error("unexpected words returned by splitWords:", parts)
+				}
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes cases where strings with nested quotes would fail i.e. `"abc:'efg'"`