### PR TITLE
Fixes process IO streaming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.14
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.14
       id: go
 
     - name: Code checkout

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
+.idea
 vendor


### PR DESCRIPTION
This PR fixes issue #22 where streaming process output from standard out would block.  This PR introduces `Proc.StdOut` and `Proc.StdErr` to stream out process IO result before the command completes.